### PR TITLE
Fix gitattributes path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you're using [Homebrew][brew], blindly run this:
 
 Once you have your dependencies installed, drop [`spaceman-diff`][binary] onto your system or your dotfiles directory or whatever kooky stuff you're using. After that, you need to configure Git to use `spaceman-diff` for all your image diffs.
 
-If you don't have one already, create a file at `~/config/git/attributes` and add this to it:
+If you don't have one already, create a file at `~/.config/git/attributes` and add this to it:
 
 ```txt
 *.png  diff=spaceman-diff


### PR DESCRIPTION
From this [SO answer](http://stackoverflow.com/questions/28026767/where-should-i-place-my-global-gitattributes-file), the user level gitattributes path should be `~/.config/git/attributes`.